### PR TITLE
Optimize inline image with jpegoptim

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ title: Limetext
     </p>
     <p>
         <a href="http://i.imgur.com/VIpmjau.png" target="_blank" title="Click for larger image">
-            <img src="http://i.imgur.com/vPjm0GX.jpg" alt="Screenshot of Lime using termbox frontend" style="height: 527px" />
+            <img src="http://i.imgur.com/q69yZW2.jpg" alt="Screenshot of Lime using termbox frontend" style="height: 527px" />
         </a>
     </p>
 </section>


### PR DESCRIPTION
I have tried both `jpegoptim` and `jpegtran`. They both gave the same results.

I've used:

```
jpegoptim --strip-all --size=90% <imagefile>
```

Which optimize the images on 90% of its original state.
It produced a 10.82% smaller image.

In response to: https://github.com/limetext/limetext.github.io/pull/7#issuecomment-29532936
